### PR TITLE
Add snyk for security testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ integration:
 	./node_modules/mocha/bin/_mocha \
 	--compilers coffee:coffee-script/register \
 	./test/integration
+security:
+	./node_modules/.bin/snyk test
 
 test:
 	$(MAKE) unit
@@ -24,7 +26,7 @@ test:
 	$(MAKE) travis-cov
 	$(MAKE) lint
 	$(MAKE) check-dependencies
-
+	$(MAKE) security
 
 compile:
 	./node_modules/coffee-script/bin/coffee -o bin -c lib/*.coffee

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "coffeelint-use-strict": "1.0.0",
     "david": "6.4.0",
     "mocha": "2.3.3",
+    "snyk": "^1.1.1",
     "travis-cov": "0.2.5"
   }
 }


### PR DESCRIPTION
```
➜  node-coderunner git:(snyk) ✗ make security
./node_modules/.bin/snyk test
✓ Tested 156 dependencies for known vulnerabilities, no vulnerabilities found.

Next steps:
- Run `snyk monitor` to be notified about new related vulnerabilities.
- Run `snyk test` as part of your CI/test.
➜  node-coderunner git:(snyk) ✗
```
